### PR TITLE
Implement task list modal

### DIFF
--- a/docs/pages/app_of_the_day/index.md
+++ b/docs/pages/app_of_the_day/index.md
@@ -1,11 +1,68 @@
 # App of the Day
 
-Welcome to **App of the Day**, a small corner of Grit Labs where we ask Codex to
-build a tiny, self contained application.  Each entry showcases how a language
-model can turn a short specification into runnable code.  These projects are not
-meant to be production ready—instead they serve as simple, reproducible
-examples you can explore or extend on your own.
+Welcome to **App of the Day**, a small corner of Grit Labs where we ask Codex to build a tiny, self contained application. Each entry showcases how a language model can turn a short specification into runnable code. These projects are not meant to be production ready—instead they serve as simple, reproducible examples you can explore or extend on your own.
 
-The first featured project is a Task List application written in vanilla
-JavaScript.  It stores tasks locally in your browser so no backend is required.
-Check out the source and try it yourself!
+The first featured project is a Task List application written in vanilla JavaScript. It stores tasks locally in your browser so no backend is required. Click the button below to try it without leaving the page.
+
+<!-- Button to open modal -->
+<button id="openModalButton">Open Task List App</button>
+
+<!-- Modal -->
+<div id="taskModal">
+  <div id="modalContent">
+    <span id="closeModal" class="close">&times;</span>
+    <iframe src="task_list.html" title="Task List App"></iframe>
+  </div>
+</div>
+
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const modal = document.getElementById("taskModal");
+  const openBtn = document.getElementById("openModalButton");
+  const closeBtn = document.getElementById("closeModal");
+  openBtn.addEventListener("click", () => {
+    modal.style.display = "flex";
+  });
+  closeBtn.addEventListener("click", () => {
+    modal.style.display = "none";
+  });
+  modal.addEventListener("click", (e) => {
+    if (e.target === modal) modal.style.display = "none";
+  });
+});
+</script>
+
+<style>
+#taskModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+#modalContent {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  position: relative;
+  width: 90%;
+  max-width: 600px;
+}
+#modalContent iframe {
+  width: 100%;
+  height: 70vh;
+  border: none;
+}
+#closeModal {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 24px;
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
## Summary
- open Task List app in a modal instead of a new page
- add inline CSS/JS for modal behavior

## Testing
- `mkdocs build -f docs/mkdocs.yml -q`

------
https://chatgpt.com/codex/tasks/task_b_686af47d092c832d9a9d75c3bf85c7df