### PR TITLE
Fix formatting for Database Structure lists

### DIFF
--- a/docs/pages/templates1/DEPENDENCY_MODELING.md
+++ b/docs/pages/templates1/DEPENDENCY_MODELING.md
@@ -30,13 +30,13 @@ Grit Labs uses explicit **Dependency Modeling** to structure relationships betwe
 
 ### Component Catalog
 
-* Stores all unique Components.
-* No self-references permitted.
+- Stores all unique Components.
+- No self-references permitted.
 
 ### Component Dependencies
 
-* Records explicit dependency relationships between components.
-* Includes an optional Parent Component reference (`ParentComponentId`).
+- Records explicit dependency relationships between components.
+- Includes an optional Parent Component reference (`ParentComponentId`).
 
 ---
 


### PR DESCRIPTION
## Summary
- ensure subsections under **Database Structure** have consistent headings and lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b1bf0ca10832dbfc6bdb3169346db