### PR TITLE
Add RUBE article to nav

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -39,6 +39,7 @@ nav:                             # make your own nav order
       - DEPENDENCY_MODELING.md: templates1/DEPENDENCY_MODELING.md
       - DIRECTIVE.md: templates1/DIRECTIVE.md
   - Articles:
+      - RUBE Four-Point Design: articles/RUBE.md
       - Top 10 Website Features: articles/top_10_website_features.md
       - Program to an Interface: articles/program_to_an_interface.md
   - App of the Day:

--- a/docs/pages/CHANGELOG.md
+++ b/docs/pages/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0 - 2025-07-08
+
+- Added the **RUBE - The Four-Point Design Approach** article and navigation link.
+
 ## v0.3.0 - 2025-07-07
 
 - Implemented the **Mutex Buttons** App of the Day with an interactive demo.


### PR DESCRIPTION
## Summary
- document new release in the changelog
- add 'RUBE Four-Point Design' entry to the Articles menu

## Testing
- `mkdocs build -f docs/mkdocs.yml`

------
https://chatgpt.com/codex/tasks/task_b_686cc4e09440832dae383b0042a6b995