### PR TITLE
Add image attribution for RUBE article

### DIFF
--- a/docs/pages/articles/RUBE.md
+++ b/docs/pages/articles/RUBE.md
@@ -151,3 +151,5 @@ img.rube-article {
 }
 
 </style>
+
+**Image attribution:** All images in this article are from [Wikimedia Commons](https://commons.wikimedia.org/wiki/Main_Page).


### PR DESCRIPTION
## Summary
- attribute RUBE article images to Wikimedia Commons

## Testing
- `mkdocs build -f docs/mkdocs.yml`

------
https://chatgpt.com/codex/tasks/task_b_686cc92b2dbc832daf35f6e3944eb3eb