### PR TITLE
Add license links

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ All content in this repository is licensed under the **GNU Affero General Public
 
 > The Grit Structured Language (GSL), including its syntax, structure, and semantics, is proprietary to Grit Labs. Any reuse, adaptation, or integration requires express permission unless covered by AGPL compliance.
 
-See `LICENSE` for full terms.
+See [`LICENSE`](https://github.com/gritlabs1/gritlabs/blob/main/LICENSE) for full terms.
 
 
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -156,7 +156,7 @@ All content in this repository is licensed under the **GNU Affero General Public
 
 > The Grit Structured Language (GSL), including its syntax, structure, and semantics, is proprietary to Grit Labs. Any reuse, adaptation, or integration requires express permission unless covered by AGPL compliance.
 
-See `LICENSE` for full terms.
+See [`LICENSE`](https://github.com/gritlabs1/gritlabs/blob/main/LICENSE) for full terms.
 
 
 

--- a/docs/pages/templates1/README.md
+++ b/docs/pages/templates1/README.md
@@ -156,7 +156,7 @@ All content in this repository is licensed under the **GNU Affero General Public
 
 > The Grit Structured Language (GSL), including its syntax, structure, and semantics, is proprietary to Grit Labs. Any reuse, adaptation, or integration requires express permission unless covered by AGPL compliance.
 
-See `LICENSE` for full terms.
+See [`LICENSE`](https://github.com/gritlabs1/gritlabs/blob/main/LICENSE) for full terms.
 
 
 


### PR DESCRIPTION
## Summary
- link the LICENSE file in docs and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686dde3d0c50832daa779af50b79bd09