### PR TITLE
Fix JavaScript spelling

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -43,7 +43,7 @@ nav:                             # make your own nav order
       - RUBE Four-Point Design: articles/RUBE.md
       - Top 10 Website Features: articles/top_10_website_features.md
       - Program to an Interface: articles/program_to_an_interface.md
-  - Javascript of the Day:
+  - JavaScript of the Day:
     - Today's App: javascript_of_the_day/index.md
     - 7/8/25 Roulette: javascript_of_the_day/roulette.md
     - 7/7/25 Mutex Buttons: javascript_of_the_day/mutex_buttons.md

--- a/docs/pages/CHANGELOG.md
+++ b/docs/pages/CHANGELOG.md
@@ -2,23 +2,23 @@
 
 ## v0.4.0 - 2025-07-08
 
-- Added a **Roulette** Javascript of the Day featuring a playable game with improved animation and spin behavior.
+- Added a **Roulette** JavaScript of the Day featuring a playable game with improved animation and spin behavior.
 - Added the **RUBE - The Four-Point Design Approach** article and a navigation link.
 - Clarified in the documentation that `GOALS.md` can express features.
 
 ## v0.3.0 - 2025-07-07
 
-- Implemented the **Mutex Buttons** Javascript of the Day with an interactive demo.
+- Implemented the **Mutex Buttons** JavaScript of the Day with an interactive demo.
 - Added a **Top 10 Website Features** article and navigation link.
 - Added fallback behavior for browsers with JavaScript disabled, including a noscript warning and redirect.
 - Enabled Mermaid diagrams with new charts for Goals and Dependency Modeling.
 
 ## v0.2.0 - 2025-07-06
 
-- Introduced the **Javascript of the Day** section featuring self-contained example applications.
+- Introduced the **JavaScript of the Day** section featuring self-contained example applications.
 - Added a Task List app written in vanilla JavaScript with accompanying HTML and CSS.
 - Embedded the Task List demo inside the documentation via an interactive modal.
-- Updated the navigation to include the new Javascript of the Day pages.
+- Updated the navigation to include the new JavaScript of the Day pages.
 
 ## v0.1.0
 

--- a/docs/pages/javascript_of_the_day/index.md
+++ b/docs/pages/javascript_of_the_day/index.md
@@ -1,6 +1,6 @@
-# Javascript of the Day
+# JavaScript of the Day
 
-Welcome to **Javascript of the Day**, a small corner of Grit Labs where we ask Codex to build a tiny, self contained application. Each entry showcases how a language model can turn a short specification into runnable code. These projects are not meant to be production ready—instead they serve as simple, reproducible examples you can explore or extend on your own.
+Welcome to **JavaScript of the Day**, a small corner of Grit Labs where we ask Codex to build a tiny, self contained application. Each entry showcases how a language model can turn a short specification into runnable code. These projects are not meant to be production ready—instead they serve as simple, reproducible examples you can explore or extend on your own.
 
 The featured project is a Roulette application written in vanilla JavaScript. It simulates a simple spin of the wheel entirely on the client side. Click the button below to try it without leaving the page.
 


### PR DESCRIPTION
## Summary
- fix 'JavaScript' capitalization in headings and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686ded816c90832d8623bdfe39470105