### PR TITLE
Fix pong modal overflow

### DIFF
--- a/docs/pages/_static/apps/pong/pong.css
+++ b/docs/pages/_static/apps/pong/pong.css
@@ -15,6 +15,8 @@ body {
     background: #000;
     display: block;
     margin: 0 auto;
+    max-width: 100%;
+    height: auto;
 }
 #score {
     margin-top: 10px;


### PR DESCRIPTION
## Summary
- keep the pong game from overflowing its modal by making the canvas responsive

## Testing
- `pre-commit` *(fails: no pre-commit configs)*

------
https://chatgpt.com/codex/tasks/task_b_686df3f60330832dac54bf3fbf48639d