### PR TITLE
Fix Roulette modal visibility

### DIFF
--- a/docs/pages/javascript_of_the_day/roulette.md
+++ b/docs/pages/javascript_of_the_day/roulette.md
@@ -8,7 +8,7 @@ To test the **Roulette App** yourself and see the functionality in action, click
 <button id="openModalButton" class="cta-btn">Open Roulette App</button>
 
 <!-- Modal -->
-<div id="rouletteModal">
+<div id="rouletteModal" style="display:none;">
   <div id="modalContent">
     <span id="closeModal" class="close">&times;</span>
     <iframe src="../../_static/apps/roulette/roulette.html" title="Roulette App"></iframe>


### PR DESCRIPTION
## Summary
- ensure the Roulette App is hidden until the modal is opened

## Testing
- `mkdocs build -q`

------
https://chatgpt.com/codex/tasks/task_b_686df81e827c832db347d9c22d1be31c