### PR TITLE
Fix memo emoji display in DIRECTIVE docs

### DIFF
--- a/docs/pages/templates1/DIRECTIVE.md
+++ b/docs/pages/templates1/DIRECTIVE.md
@@ -44,7 +44,7 @@ You will be given:
 
 5. **Do not overwrite past Action Schemas.** Each Rotation must produce a new, separately versioned schema.
 
-   > \:memo: **NOTE:** Because past Action Schemas must not be overwritten, managing Action Items using Canvas is strictly prohibited.
+   > :memo: **NOTE:** Because past Action Schemas must not be overwritten, managing Action Items using Canvas is strictly prohibited.
 
 6. Return **only** the updated Action Schema table (with updated title/version line)—no narrative explanations or commentary.
 


### PR DESCRIPTION
## Summary
- remove backslash escaping in note for DIRECTIVE template so `:memo:` renders as an emoji

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_686e95269534832d8be0cc083b53b5d7