### PR TITLE
Add archived known issues page

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,7 +49,9 @@ nav:                             # make your own nav order
       - 7/8/25 Roulette: javascript_of_the_day/roulette.md
       - 7/7/25 Mutex Buttons: javascript_of_the_day/mutex_buttons.md
       - 7/6/25 Task List: javascript_of_the_day/task_list.md
-  - Known Issues: known_issues/index.md
+  - Known Issues:
+      - Known Issues: known_issues/index.md
+      - Archived: known_issues/archived_known_issues.md
   - Changelog: CHANGELOG.md
 
 extra:

--- a/docs/pages/known_issues/AGENTS.md
+++ b/docs/pages/known_issues/AGENTS.md
@@ -18,6 +18,7 @@ An LLM working in this folder should:
 - Treat all rules as **live prompt checks**, not memory
 - Enforce formatting consistency with Markdown tables and filenames
 - Use 5-digit padded issue IDs (e.g., `00042`) in all listings and links
+- Keep issue tables on both pages sorted by descending ID
 
 ---
 

--- a/docs/pages/known_issues/archived_known_issues.md
+++ b/docs/pages/known_issues/archived_known_issues.md
@@ -1,0 +1,6 @@
+# Archived Known Issues
+
+Resolved or outdated issues are listed here for historical reference.
+
+| ID | Title | Status | Date Reported | Component | Notes / Workaround |
+|----|-------|--------|---------------|-----------|--------------------|


### PR DESCRIPTION
## Summary
- add rule to keep issue tables sorted in `known_issues/AGENTS.md`
- add placeholder `archived_known_issues.md` for old items
- list `Archived` under Known Issues in the docs menu

## Testing
- `pip install mkdocs mkdocs-material`
- `mkdocs build -f docs/mkdocs.yml --strict`

------
https://chatgpt.com/codex/tasks/task_b_686ed6799030832dbdd666855002c080