### PR TITLE
Fix JS path for known issues tables

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -64,8 +64,8 @@ extra_javascript:
   - _static/control-scrollspy-nav.js
   - _static/mermaid-init.js  # Custom initialization script
   - https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.min.js
-  - js/simple-datatables.min.js
-  - js/init-known-issues-tables.js
+  - _static/simple-datatables.min.js
+  - _static/init-known-issues-tables.js
 
 
   


### PR DESCRIPTION
## Summary
- move known issues table JS references to `_static`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686eea697f5c832da76a60064810adc3