### PR TITLE
Fix Known Issues script path

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -65,8 +65,8 @@ extra_javascript:
   - _static/control-scrollspy-nav.js
   - _static/mermaid-init.js  # Custom initialization script
   - https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.min.js
-  - js/simple-datatables.min.js
-  - js/init-known-issues-tables.js
+  - _static/simple-datatables.min.js
+  - _static/init-known-issues-tables.js
 
 
   


### PR DESCRIPTION
## Summary
- adjust JS paths in `mkdocs.yml` so the Known Issues table loads its sorting script

## Testing
- `mkdocs build -f docs/mkdocs.yml -d /tmp/site2`


------
https://chatgpt.com/codex/tasks/task_b_686efd62be50832dacc8de0cd0a5e215