### PR TITLE
Update changelog for v0.5.0 release

### DIFF
--- a/docs/pages/changelog/index.md
+++ b/docs/pages/changelog/index.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.5.0 - 2025-07-10
+
+### Features
+- Moved all JavaScript assets to the `_static` directory.
+- Enabled interactive table sorting using the Tablesort library.
+- Backfilled known issues data and reorganized past releases.
+
+### Fixes to Known Issues
+- None.
+
 
 ## v0.4.0 - 2025-07-08
 


### PR DESCRIPTION
## Summary
- add entry for v0.5.0 released 2025-07-10

## Testing
- `mkdocs build -f docs/mkdocs.yml -d site`

------
https://chatgpt.com/codex/tasks/task_b_686f388438cc832da41f391ebb1120e5