### PR TITLE
Update changelog with commit links

### DIFF
--- a/docs/pages/changelog/index.md
+++ b/docs/pages/changelog/index.md
@@ -22,9 +22,9 @@
 - Clarified in the documentation that `GOALS.md` can express features.
 
 ### Fixes to Known Issues
-- Roulette wheel numbers were hard to see; commit `b83149b` changed them to white for better contrast. ([#00003](../known_issues/2025/07/00003.md))
-- Roulette wheel spin logic was erratic; commit `535f019` corrected the start and stop positions. ([#00002](../known_issues/2025/07/00002.md))
-- Pong game paddle lacked touch controls; commit `57162b8` enabled finger tracking. ([#00001](../known_issues/2025/07/00001.md))
+- Roulette wheel numbers were hard to see; commit [`b83149b`](https://github.com/gritlabs/gritlabs/commit/b83149b) changed them to white for better contrast. ([#00003](../known_issues/2025/07/00003.md))
+- Roulette wheel spin logic was erratic; commit [`535f019`](https://github.com/gritlabs/gritlabs/commit/535f019) corrected the start and stop positions. ([#00002](../known_issues/2025/07/00002.md))
+- Pong game paddle lacked touch controls; commit [`57162b8`](https://github.com/gritlabs/gritlabs/commit/57162b8) enabled finger tracking. ([#00001](../known_issues/2025/07/00001.md))
 
 ## v0.3.0 - 2025-07-07
 


### PR DESCRIPTION
## Summary
- link commit references in changelog to GitHub URLs

## Testing
- `pip install -r requirements.txt`
- `mkdocs build -f docs/mkdocs.yml -d site`

------
https://chatgpt.com/codex/tasks/task_b_686f3fbdd3d8832d9bed5140f7353fa7