### PR TITLE
Fix commit links

### DIFF
--- a/docs/pages/changelog/index.md
+++ b/docs/pages/changelog/index.md
@@ -22,9 +22,9 @@
 - Clarified in the documentation that `GOALS.md` can express features.
 
 ### Fixes to Known Issues
-- Roulette wheel numbers were hard to see; commit [`b83149b`](https://github.com/gritlabs/gritlabs/commit/b83149b) changed them to white for better contrast. ([#00003](../known_issues/2025/07/00003.md))
-- Roulette wheel spin logic was erratic; commit [`535f019`](https://github.com/gritlabs/gritlabs/commit/535f019) corrected the start and stop positions. ([#00002](../known_issues/2025/07/00002.md))
-- Pong game paddle lacked touch controls; commit [`57162b8`](https://github.com/gritlabs/gritlabs/commit/57162b8) enabled finger tracking. ([#00001](../known_issues/2025/07/00001.md))
+- Roulette wheel numbers were hard to see; commit [`b83149b`](https://github.com/gritlabs1/gritlabs/commit/b83149b) changed them to white for better contrast. ([#00003](../known_issues/2025/07/00003.md))
+- Roulette wheel spin logic was erratic; commit [`535f019`](https://github.com/gritlabs1/gritlabs/commit/535f019) corrected the start and stop positions. ([#00002](../known_issues/2025/07/00002.md))
+- Pong game paddle lacked touch controls; commit [`57162b8`](https://github.com/gritlabs1/gritlabs/commit/57162b8) enabled finger tracking. ([#00001](../known_issues/2025/07/00001.md))
 
 ## v0.3.0 - 2025-07-07
 

--- a/docs/pages/known_issues/2025/07/00001.md
+++ b/docs/pages/known_issues/2025/07/00001.md
@@ -3,6 +3,6 @@
 **Status:** Closed
 **Date Reported:** 2025-07-10
 
-Mobile users could not control the paddle in the Pong game. Commit `57162b8` added touch support so the paddle follows finger movements. This fix landed on **2025-07-10**.
+Mobile users could not control the paddle in the Pong game. Commit [`57162b8`](https://github.com/gritlabs1/gritlabs/commit/57162b8) added touch support so the paddle follows finger movements. This fix landed on **2025-07-10**.
 
 [← Back to Known Issues](../../index.md)

--- a/docs/pages/known_issues/2025/07/00002.md
+++ b/docs/pages/known_issues/2025/07/00002.md
@@ -3,6 +3,6 @@
 **Status:** Closed
 **Date Reported:** 2025-07-08
 
-The roulette wheel occasionally accelerated unexpectedly. Commit `535f019` revised the spin logic so each spin starts from the correct position and stops smoothly.
+The roulette wheel occasionally accelerated unexpectedly. Commit [`535f019`](https://github.com/gritlabs1/gritlabs/commit/535f019) revised the spin logic so each spin starts from the correct position and stops smoothly.
 
 [← Back to Known Issues](../../index.md)

--- a/docs/pages/known_issues/2025/07/00003.md
+++ b/docs/pages/known_issues/2025/07/00003.md
@@ -3,6 +3,6 @@
 **Status:** Closed
 **Date Reported:** 2025-07-08
 
-Initial versions of the roulette game used red and black text for the wheel numbers, making them difficult to read. Commit `b83149b` changed the numbers to white for better contrast.
+Initial versions of the roulette game used red and black text for the wheel numbers, making them difficult to read. Commit [`b83149b`](https://github.com/gritlabs1/gritlabs/commit/b83149b) changed the numbers to white for better contrast.
 
 [← Back to Known Issues](../../index.md)


### PR DESCRIPTION
## Summary
- update commit links to use gritlabs1/gritlabs
- link commits in Known Issues pages

## Testing
- `pip install -r requirements.txt`
- `mkdocs build -f docs/mkdocs.yml`


------
https://chatgpt.com/codex/tasks/task_b_686f42597f84832d9e9438491cd89d97