### PR TITLE
Fix changelog entries for Pong game

### DIFF
--- a/docs/pages/CHANGELOG.md
+++ b/docs/pages/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.5.0 - 2025-07-09
+
+- 7/9/2025: Pong game paddle needed fix.
+- Pong game paddle lacked touch controls; commit 57162b8 enabled finger tracking. (#00001)
+
+## v0.4.0 - 2025-07-08
+
+- Introduced the Pong game as a new example.
+
 ## v0.3.0 - 2025-07-07
 
 - Implemented the **Mutex Buttons** App of the Day with an interactive demo.


### PR DESCRIPTION
## Summary
- add missing v0.4.0 and v0.5.0 sections
- correct the date for the Pong game paddle fix
- move finger-tracking bullet to v0.5.0

## Testing
- `pip install -r requirements.txt`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_b_686f4548c074832da053b8af65b88657