### PR TITLE
Add Pac Man JavaScript of the Day app

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -45,6 +45,7 @@ nav:                             # make your own nav order
       - Program to an Interface: articles/program_to_an_interface.md
   - JavaScript of the Day:
       - Today's App: javascript_of_the_day/index.md
+      - 7/10/25 Pac Man: javascript_of_the_day/pac_man.md
       - 7/9/25 Pong Game: javascript_of_the_day/pong.md
       - 7/8/25 Roulette: javascript_of_the_day/roulette.md
       - 7/7/25 Mutex Buttons: javascript_of_the_day/mutex_buttons.md

--- a/docs/pages/_static/apps/pac_man/pac_man.css
+++ b/docs/pages/_static/apps/pac_man/pac_man.css
@@ -1,0 +1,20 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+    margin: 0;
+    padding: 20px;
+}
+.container {
+    max-width: 420px;
+    margin: auto;
+    background: white;
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    text-align: center;
+}
+canvas {
+    background: #000;
+    display: block;
+    margin: 0 auto;
+}

--- a/docs/pages/_static/apps/pac_man/pac_man.html
+++ b/docs/pages/_static/apps/pac_man/pac_man.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pac Man App</title>
+    <link rel="stylesheet" href="pac_man.css">
+</head>
+<body>
+    <div class="container">
+        <canvas id="gameCanvas" width="400" height="400"></canvas>
+    </div>
+    <script src="pac_man.js"></script>
+</body>
+</html>

--- a/docs/pages/_static/apps/pac_man/pac_man.js
+++ b/docs/pages/_static/apps/pac_man/pac_man.js
@@ -1,0 +1,106 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+const cellSize = 20;
+const rows = canvas.width / cellSize;
+const cols = canvas.height / cellSize;
+
+const pacman = { x: 10, y: 10, dx: 0, dy: 0 };
+const ghost = { x: 1, y: 1 };
+let dots = [];
+
+for (let i = 0; i < rows; i++) {
+    for (let j = 0; j < cols; j++) {
+        if (!(i === pacman.x && j === pacman.y)) {
+            dots.push({ x: i, y: j });
+        }
+    }
+}
+
+function drawCircle(x, y, color) {
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(x * cellSize + cellSize / 2, y * cellSize + cellSize / 2, cellSize / 2 - 2, 0, Math.PI * 2);
+    ctx.fill();
+}
+
+function drawPacman() {
+    ctx.fillStyle = 'yellow';
+    ctx.beginPath();
+    const px = pacman.x * cellSize + cellSize / 2;
+    const py = pacman.y * cellSize + cellSize / 2;
+    ctx.arc(px, py, cellSize / 2 - 2, 0.25 * Math.PI, 1.75 * Math.PI);
+    ctx.lineTo(px, py);
+    ctx.fill();
+}
+
+function drawGhost() {
+    drawCircle(ghost.x, ghost.y, 'red');
+}
+
+function drawDots() {
+    ctx.fillStyle = 'white';
+    dots.forEach(d => {
+        ctx.beginPath();
+        ctx.arc(d.x * cellSize + cellSize / 2, d.y * cellSize + cellSize / 2, 3, 0, Math.PI * 2);
+        ctx.fill();
+    });
+}
+
+function move(entity, dx, dy) {
+    entity.x = Math.max(0, Math.min(rows - 1, entity.x + dx));
+    entity.y = Math.max(0, Math.min(cols - 1, entity.y + dy));
+}
+
+function update() {
+    move(pacman, pacman.dx, pacman.dy);
+    pacman.dx = pacman.dy = 0;
+    if (Math.random() < 0.3) {
+        const dir = Math.floor(Math.random() * 4);
+        if (dir === 0) move(ghost, 1, 0);
+        if (dir === 1) move(ghost, -1, 0);
+        if (dir === 2) move(ghost, 0, 1);
+        if (dir === 3) move(ghost, 0, -1);
+    }
+    dots = dots.filter(d => !(d.x === pacman.x && d.y === pacman.y));
+    if (pacman.x === ghost.x && pacman.y === ghost.y) {
+        alert('Game Over!');
+        reset();
+    }
+    if (dots.length === 0) {
+        alert('You Win!');
+        reset();
+    }
+}
+
+function reset() {
+    pacman.x = 10; pacman.y = 10;
+    ghost.x = 1; ghost.y = 1;
+    dots = [];
+    for (let i = 0; i < rows; i++) {
+        for (let j = 0; j < cols; j++) {
+            if (!(i === pacman.x && j === pacman.y)) {
+                dots.push({ x: i, y: j });
+            }
+        }
+    }
+}
+
+function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawDots();
+    drawGhost();
+    drawPacman();
+}
+
+function loop() {
+    update();
+    draw();
+}
+setInterval(loop, 200);
+
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowUp') pacman.dy = -1;
+    if (e.key === 'ArrowDown') pacman.dy = 1;
+    if (e.key === 'ArrowLeft') pacman.dx = -1;
+    if (e.key === 'ArrowRight') pacman.dx = 1;
+});

--- a/docs/pages/javascript_of_the_day/pac_man.md
+++ b/docs/pages/javascript_of_the_day/pac_man.md
@@ -1,8 +1,8 @@
-# JavaScript of the Day
+# Pac Man App
 
-Welcome to **JavaScript of the Day**, a small corner of Grit Labs where we ask Codex to build a tiny, self contained JavaScript application. Each entry showcases how a language model can turn a short specification into runnable code. These projects are not meant to be production ready—instead they serve as simple, reproducible examples you can explore or extend on your own.
+### Try It Now
 
-The featured project is a Pac Man game written in vanilla JavaScript. Munch all the dots while avoiding the ghost. Click the button below to try it without leaving the page.
+To play **Pac Man** right here in your browser, click the link below:
 
 <!-- Button to open modal -->
 <button id="openModalButton" class="cta-btn">Open Pac Man App</button>
@@ -14,6 +14,27 @@ The featured project is a Pac Man game written in vanilla JavaScript. Munch all 
     <iframe src="../../_static/apps/pac_man/pac_man.html" title="Pac Man App"></iframe>
   </div>
 </div>
+
+### Overview
+
+The **Pac Man App** is a simplified homage to the classic arcade game. Move Pac Man around the grid to eat all the dots while avoiding the roaming ghost.
+
+### Features
+
+- **Arrow Key Controls:** Use the arrow keys to navigate Pac Man.
+- **Random Ghost:** A red ghost moves unpredictably around the board.
+- **Dot Collection:** Clear the board by eating every dot.
+- **Pure Client-Side:** Built entirely with HTML5 Canvas and vanilla JavaScript.
+
+### Purpose
+
+This project demonstrates how Codex can generate an interactive game complete with basic AI and keyboard controls. Everything runs locally in your browser with no backend.
+
+### How It Works
+
+1. **Movement:** Pac Man moves one grid cell in the direction of the pressed arrow key.
+2. **Ghost AI:** The ghost randomly chooses a direction at intervals.
+3. **Win/Lose Conditions:** Clear all dots to win or collide with the ghost to end the game.
 
 <script>
 document.addEventListener("DOMContentLoaded", function () {
@@ -33,6 +54,7 @@ document.addEventListener("DOMContentLoaded", function () {
 </script>
 
 <style>
+/* Same styles as other JavaScript of the Day modals */
 #pac_manModal {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- create Pac Man game assets
- feature Pac Man on JavaScript of the Day landing page
- archive Pac Man app page
- add Pac Man entry to navigation

## Testing
- `mkdocs build --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686fe5b5e960832da3c8fe4de8a9f5db