### PR TITLE
Remove Pac Man mobile styling

### DIFF
--- a/docs/pages/_static/apps/pac_man/pac_man.css
+++ b/docs/pages/_static/apps/pac_man/pac_man.css
@@ -35,19 +35,11 @@ canvas {
     color: #555;
     margin-bottom: 10px;
 }
+.start-instruction {
+    color: #555;
+    margin-bottom: 10px;
+}
 button {
     margin-top: 10px;
     padding: 6px 12px;
-}
-@media (max-width: 500px) {
-    #gameTitle::after {
-        content: " mini";
-    }
-    body {
-        font-size: 0.9rem;
-    }
-    button {
-        font-size: 0.9rem;
-        padding: 4px 8px;
-    }
 }

--- a/docs/pages/_static/apps/pac_man/pac_man.html
+++ b/docs/pages/_static/apps/pac_man/pac_man.html
@@ -11,6 +11,7 @@
         <h1 id="gameTitle">Pac-Man</h1>
         <div id="score">Score: 0</div>
         <p class="instructions">Use the arrow keys to move Pac-Man. Touch devices aren't supported.</p>
+        <p class="start-instruction">Press the up arrow to get started.</p>
         <div class="game-wrapper">
             <canvas id="gameCanvas"></canvas>
         </div>


### PR DESCRIPTION
## Summary
- remove Pac Man mini styling
- add start instruction to Pac Man game screen

## Testing
- `mkdocs build -f docs/mkdocs.yml`

------
https://chatgpt.com/codex/tasks/task_b_68701f9b2774832da6370075010d48a4