### PR TITLE
Add AI-generated content article to nav

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -39,6 +39,7 @@ nav:                             # make your own nav order
       - DEPENDENCY_MODELING.md: templates1/DEPENDENCY_MODELING.md
       - DIRECTIVE.md: templates1/DIRECTIVE.md
   - Articles:
+      - AI-Generated Content and Attribution: articles/ai_generated_content_and_attribution.md
       - Best Practices for Closing Pull Requests: articles/closing_pull_requests.md
       - RUBE Four-Point Design: articles/RUBE.md
       - Top 10 Website Features: articles/top_10_website_features.md


### PR DESCRIPTION
## Summary
- add `AI-Generated Content and Attribution` to the Articles navigation

## Testing
- `mkdocs build -f docs/mkdocs.yml -d site`

------
https://chatgpt.com/codex/tasks/task_b_687035d12154832dba0d15fd3bf31ecf