### PR TITLE
Move versioning scheme to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,14 @@ An LLM working in this repo should:
 
 ---
 
+### Action Schema Versioning Rules
+
+* Every Action Schema must begin with a PascalCase title followed by a version identifier (`— vX.Y`).
+* Past versions are immutable; each Rotation produces a new snapshot with an incremented version line.
+* Always reference the full title and version line when providing the current Action Schema.
+
+---
+
 ## Notes
 
 * Do not include human workflow tracking in this file.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Grit Labs optimizes for:
 |-------------------|-----------------------------------------------------------------------------------------|
 | **README.md**     | One-screen introduction and quick-start guide                                           |
 | **TERMINOLOGY.md**| Template defining the shared vocabulary of Grit Labs                                                        |
-| **ACTION_SCHEMA.md** | Template specifying the Action Items table format & rules (PascalCase title + version)        |
+| **ACTION_SCHEMA.md** | Template specifying the Action Items table format & rules |
 | **DIRECTIVE.md** | Template instructing an LLM how to run a Rotation                                                  |                                  |
 | **GOALS.md** (optional)|  Template defining Missions, Goals, and Acceptance Tests. Provides traceable, testable structure for reasoning and documentation.|
 | **DEPENDENCY_MODELING.md** (optional)| Template specifying component relationships, dependencies, and use cases. |
@@ -84,13 +84,13 @@ Grit Labs optimizes for:
 * Defines the **Problem Space** for the current rotation  
 * Updates Action Items via **Notes** and **Triggers**  
 * Executes fully in the present moment  
-* Treats every Action Schema as an immutable, versionable snapshot  
+* Treats every Action Schema as an immutable snapshot
 
 ---
 
 ## 🔄 Running a Rotation
 
-1. Provide the current **Action Schema** (PascalCase title + version)  
+1. Provide the current **Action Schema**
 2. Add any new **Action Notes** or **Action Triggers**  
 3. Apply the **Rotation Directive** (`DIRECTIVE.md`)  
 4. Accept the updated table and act on the next visible work  

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -62,7 +62,7 @@ Grit Labs optimizes for:
 |-------------------|-----------------------------------------------------------------------------------------|
 | **README.md**     | One-screen introduction and quick-start guide                                           |
 | **TERMINOLOGY.md**| Template defining the shared vocabulary of Grit Labs                                                        |
-| **ACTION_SCHEMA.md** | Template specifying the Action Items table format & rules (PascalCase title + version)        |
+| **ACTION_SCHEMA.md** | Template specifying the Action Items table format & rules |
 | **DIRECTIVE.md** | Template instructing an LLM how to run a Rotation                                                  |                                  |
 | **GOALS.md** (optional)|  Template defining Missions, Goals, and Acceptance Tests. Provides traceable, testable structure for reasoning and documentation.|
 | **DEPENDENCY_MODELING.md** (optional)| Template specifying component relationships, dependencies, and use cases. |
@@ -84,13 +84,13 @@ Grit Labs optimizes for:
 * Defines the **Problem Space** for the current rotation  
 * Updates Action Items via **Notes** and **Triggers**  
 * Executes fully in the present moment  
-* Treats every Action Schema as an immutable, versionable snapshot  
+* Treats every Action Schema as an immutable snapshot
 
 ---
 
 ## 🔄 Running a Rotation
 
-1. Provide the current **Action Schema** (PascalCase title + version)  
+1. Provide the current **Action Schema**
 2. Add any new **Action Notes** or **Action Triggers**  
 3. Apply the **Rotation Directive** (`DIRECTIVE.md`)  
 4. Accept the updated table and act on the next visible work  

--- a/docs/pages/templates1/README.md
+++ b/docs/pages/templates1/README.md
@@ -62,7 +62,7 @@ Grit Labs optimizes for:
 |-------------------|-----------------------------------------------------------------------------------------|
 | **README.md**     | One-screen introduction and quick-start guide                                           |
 | **TERMINOLOGY.md**| Template defining the shared vocabulary of Grit Labs                                                        |
-| **ACTION_SCHEMA.md** | Template specifying the Action Items table format & rules (PascalCase title + version)        |
+| **ACTION_SCHEMA.md** | Template specifying the Action Items table format & rules |
 | **DIRECTIVE.md** | Template instructing an LLM how to run a Rotation                                                  |                                  |
 | **GOALS.md** (optional)|  Template defining Missions, Goals, and Acceptance Tests. Provides traceable, testable structure for reasoning and documentation.|
 | **DEPENDENCY_MODELING.md** (optional)| Template specifying component relationships, dependencies, and use cases. |
@@ -84,13 +84,13 @@ Grit Labs optimizes for:
 * Defines the **Problem Space** for the current rotation  
 * Updates Action Items via **Notes** and **Triggers**  
 * Executes fully in the present moment  
-* Treats every Action Schema as an immutable, versionable snapshot  
+* Treats every Action Schema as an immutable snapshot
 
 ---
 
 ## 🔄 Running a Rotation
 
-1. Provide the current **Action Schema** (PascalCase title + version)  
+1. Provide the current **Action Schema**
 2. Add any new **Action Notes** or **Action Triggers**  
 3. Apply the **Rotation Directive** (`DIRECTIVE.md`)  
 4. Accept the updated table and act on the next visible work  


### PR DESCRIPTION
## Summary
- move versioning guidance out of README files
- keep README.md, index.md, and templates1 README in sync
- document Action Schema versioning rules in the global AGENTS.md

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687045cb6a24832d8bd7897358ff7d18