### PR TITLE
Remove proprietary GSL notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ Then open `http://localhost:8000` in your browser.
 
 All content in this repository is licensed under the **GNU Affero General Public License v3.0 (AGPL)**.
 
-> The Grit Structured Language (GSL), including its syntax, structure, and semantics, is proprietary to Grit Labs. Any reuse, adaptation, or integration requires express permission unless covered by AGPL compliance.
 
 See [`LICENSE`](https://github.com/gritlabs1/gritlabs/blob/main/LICENSE) for full terms.
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -184,7 +184,6 @@ Then open `http://localhost:8000` in your browser.
 
 All content in this repository is licensed under the **GNU Affero General Public License v3.0 (AGPL)**.
 
-> The Grit Structured Language (GSL), including its syntax, structure, and semantics, is proprietary to Grit Labs. Any reuse, adaptation, or integration requires express permission unless covered by AGPL compliance.
 
 See [`LICENSE`](https://github.com/gritlabs1/gritlabs/blob/main/LICENSE) for full terms.
 

--- a/docs/pages/templates1/README.md
+++ b/docs/pages/templates1/README.md
@@ -184,7 +184,6 @@ Then open `http://localhost:8000` in your browser.
 
 All content in this repository is licensed under the **GNU Affero General Public License v3.0 (AGPL)**.
 
-> The Grit Structured Language (GSL), including its syntax, structure, and semantics, is proprietary to Grit Labs. Any reuse, adaptation, or integration requires express permission unless covered by AGPL compliance.
 
 See [`LICENSE`](https://github.com/gritlabs1/gritlabs/blob/main/LICENSE) for full terms.
 


### PR DESCRIPTION
## Summary
- remove proprietary Grit Structured Language line from license sections

## Testing
- `mkdocs build -f docs/mkdocs.yml -d site`

------
https://chatgpt.com/codex/tasks/task_b_6872b10da048832d95488644774148b0