### PR TITLE
Fix edit task functionality

### DIFF
--- a/docs/pages/_static/apps/smart-js-tasks/smart-js-tasks.js
+++ b/docs/pages/_static/apps/smart-js-tasks/smart-js-tasks.js
@@ -25,7 +25,8 @@ function renderTasks(tasks) {
         const editBtn = document.createElement('button');
         editBtn.textContent = 'Edit';
         editBtn.className = 'edit';
-        editBtn.addEventListener('click', () => editTask(t.id));
+        editBtn.dataset.taskId = t.id;
+        editBtn.addEventListener('click', startEdit);
         const delBtn = document.createElement('button');
         delBtn.textContent = 'Delete';
         delBtn.className = 'delete';
@@ -34,6 +35,11 @@ function renderTasks(tasks) {
         li.appendChild(delBtn);
         listEl.appendChild(li);
     });
+}
+
+function startEdit(e) {
+    const id = e.currentTarget.dataset.taskId;
+    editTask(id);
 }
 
 async function createTask() {


### PR DESCRIPTION
## Summary
- ensure edit button stores `taskId` on dataset
- send the proper task id when updating a task

## Testing
- `pip install --user -r requirements.txt`
- `mkdocs build -f docs/mkdocs.yml -d site`

------
https://chatgpt.com/codex/tasks/task_b_68740bab06ec832d8b663b77dc64a6c6