### PR TITLE
Add visitor tracking script

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -66,15 +66,16 @@ nav:                             # make your own nav order
 extra:
   generator: false          # ← hides the “Made with …” line
   
-extra_css:                  #  center copyright
-  - _static/extra.css?v=20250515
-extra_javascript:
-  - _static/open-repo-in-new-tab.js
-  - _static/control-scrollspy-nav.js
-  - _static/mermaid-init.js  # Custom initialization script
-  - https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.min.js
-  - _static/tablesort.min.js
-  - _static/init-tablesort.js
+  extra_css:                  #  center copyright
+    - _static/extra.css?v=20250515
+  extra_javascript:
+    - _static/open-repo-in-new-tab.js
+    - _static/control-scrollspy-nav.js
+    - _static/mermaid-init.js  # Custom initialization script
+    - https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.min.js
+    - _static/tablesort.min.js
+    - _static/init-tablesort.js
+    - pages/_static/visitor-tracking.js
 docs_dir: pages        # <— tell MkDocs where to look
   
 copyright: "© 2025 Grit Labs | Site developed with ChatGPT and Codex"


### PR DESCRIPTION
## Summary
- include visitor-tracking.js in MkDocs build

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_b_68746a9e7f24832d9c6faee3099733e5