### PR TITLE
Fix missing footer CSS

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -65,17 +65,17 @@ nav:                             # make your own nav order
 
 extra:
   generator: false          # ← hides the “Made with …” line
-  
-  extra_css:                  #  center copyright
-    - _static/extra.css?v=20250515
-  extra_javascript:
-    - _static/open-repo-in-new-tab.js
-    - _static/control-scrollspy-nav.js
-    - _static/mermaid-init.js  # Custom initialization script
-    - https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.min.js
-    - _static/tablesort.min.js
-    - _static/init-tablesort.js
-    - _static/visitor-tracking.js
+
+extra_css:                  #  center copyright
+  - _static/extra.css?v=20250515
+extra_javascript:
+  - _static/open-repo-in-new-tab.js
+  - _static/control-scrollspy-nav.js
+  - _static/mermaid-init.js  # Custom initialization script
+  - https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.min.js
+  - _static/tablesort.min.js
+  - _static/init-tablesort.js
+  - _static/visitor-tracking.js
 docs_dir: pages        # <— tell MkDocs where to look
   
 copyright: "© 2025 Grit Labs | Site developed with ChatGPT and Codex"


### PR DESCRIPTION
## Summary
- restore `extra_css`/`extra_javascript` to the root level in `mkdocs.yml`

## Testing
- `pip install -q -r requirements.txt`
- `mkdocs build -f docs/mkdocs.yml -q`


------
https://chatgpt.com/codex/tasks/task_b_687473451e5c832d9396de68993e4d0a