### PR TITLE
Add prompts for Mutex Buttons API and UI

### DIFF
--- a/angular_ui.md
+++ b/angular_ui.md
@@ -1,0 +1,35 @@
+# Prompt for UI Agent: Mutex Buttons in Angular
+
+Build a new Angular frontend that faithfully reproduces the **Mutex Buttons** app currently found in the `JavaScript of the Day` section. The layout, button labels, and power toggle behavior must remain the same, but the app should be styled using Angular components to look more polished.
+
+## 1. Preserve Existing Behaviors
+
+- Power button toggles the entire button panel on and off.
+- Four input buttons (HDMI, VGA, HDMI Audio, 1/8" Audio) act as a mutually exclusive set.
+- Status text reflects whether the panel is off or which input is active.
+- Use `localStorage` to keep `panelOn` and `selectedInput` so the state persists offline.
+
+## 2. Integrate Real API
+
+- Connect to the endpoints defined in `mutex_api.md`:
+  - `GET /api/mutex/state`
+  - `GET /api/mutex/history`
+  - `POST /api/mutex/state`
+- After each local state change, send a POST request to record the event.
+- On app start, load the current state from the API and fall back to `localStorage` if unreachable.
+
+## 3. Angular Structure
+
+- Create a single module named `MutexModule` containing:
+  - `MutexComponent` for the UI layout and interactions.
+  - `MutexService` for HTTP calls and local storage sync.
+- Template layout mirrors the existing HTML: a header with a power button, a two-column grid of input buttons, and a status paragraph beneath.
+- Apply Angular styling (e.g., Angular Material or your own SCSS) for a cleaner look while keeping the button positions and modal-like container.
+
+## 4. Additional Notes
+
+- Ensure keyboard accessibility for the buttons.
+- Handle API errors gracefully and continue using local storage when offline.
+
+---
+This concludes the directives for the UI Agent.

--- a/mutex_api.md
+++ b/mutex_api.md
@@ -1,0 +1,35 @@
+# Prompt for API Agent: Add Mutex Module
+
+You are tasked with extending an existing .NET WebAPI so that it can store and retrieve data produced by the **Mutex Buttons** app.
+Follow these directives when writing the API implementation:
+
+## 1. Database
+
+1. Create a new table named `MutexEvents`.
+2. Schema:
+   - `Id` (int, primary key, identity)
+   - `Timestamp` (datetime, not null)
+   - `PanelOn` (bit, not null)
+   - `SelectedInput` (nvarchar(50), nullable)
+3. Each time a user toggles power or chooses a button, insert a row with the new state.
+
+## 2. API Routes
+
+Define the following routes under a `Mutex` controller namespace.
+
+| Verb | Route | Purpose |
+|-----|-------|---------|
+| GET | `/api/mutex/state` | Returns the most recent `MutexEvents` record. |
+| GET | `/api/mutex/history` | Returns all events ordered by newest first. |
+| POST | `/api/mutex/state` | Accepts `{ panelOn: bool, selectedInput: string }` and inserts a new record. |
+
+The POST request should be idempotent for unchanged state. Use dependency injection for the data context.
+
+## 3. Module Integration
+
+* Add a service class `MutexService` with methods to read the current state and append events.
+* Register the service and controller in the existing WebAPI project.
+* Ensure cross-origin requests are allowed for the Angular frontend.
+
+---
+This concludes the directives for the API Agent.


### PR DESCRIPTION
## Summary
- provide prompt for .NET API to store and expose Mutex Buttons state
- outline Angular UI prompt to replicate existing JavaScript app with API integration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687550b85890832d8c04bc9d6be4ef4a