### PR TITLE
Add h4 heading rule to articles

### DIFF
--- a/docs/pages/articles/AGENTS.md
+++ b/docs/pages/articles/AGENTS.md
@@ -16,6 +16,7 @@ An LLM managing the navigation menu must:
 
 - Sort articles listed in `docs/mkdocs.yml` under the **Articles** section by commit date, newest first and oldest last.
 - Ensure the article **The Fragile Genius of LLMs** remains the third item listed under the **Articles** section of `docs/mkdocs.yml`.
+- Articles must not contain `<h3>` HTML heading tags. Replace any detected `<h3>` elements with `<h4>`.
 
 ---
 

--- a/docs/pages/articles/code-review-best-practices.md
+++ b/docs/pages/articles/code-review-best-practices.md
@@ -30,6 +30,6 @@ Positive feedback matters. Call out clever solutions or improvements you appreci
 
 ---
 
-### Conclusion
+#### Conclusion
 
 Code reviews are a lightweight ritual with big returns. By keeping pull requests focused, providing context, and emphasizing collaboration, your team can ship quality code and learn from each other along the way.

--- a/docs/pages/articles/database-driven-design.md
+++ b/docs/pages/articles/database-driven-design.md
@@ -16,22 +16,22 @@ In Database-Driven Design, the **relational database schema** becomes the source
 
 ## ✨ 2. Benefits of DBDD
 
-### 2.1 Simpler for CRUD-heavy Applications
+#### 2.1 Simpler for CRUD-heavy Applications
 
 * For apps with heavy **Create, Read, Update, Delete** operations, DBDD allows quick iteration.
 * Ideal for **admin panels**, **reporting tools**, and **data dashboards**.
 
-### 2.2 Easier to Onboard
+#### 2.2 Easier to Onboard
 
 * Developers and analysts can often understand the system by reading the schema.
 * Aligns well with SQL-centric teams.
 
-### 2.3 Strong Data Integrity
+#### 2.3 Strong Data Integrity
 
 * Heavily uses **normalized schemas**, **foreign keys**, and **stored procedures** to enforce rules.
 * Validations often live in the database.
 
-### 2.4 Better for Data Warehousing and Reporting
+#### 2.4 Better for Data Warehousing and Reporting
 
 * Schema-first designs are easier to integrate with BI tools, ETL pipelines, and reporting engines.
 
@@ -39,22 +39,22 @@ In Database-Driven Design, the **relational database schema** becomes the source
 
 ## ⚠️ 3. Drawbacks of DBDD
 
-### 3.1 Rigid and Inflexible
+#### 3.1 Rigid and Inflexible
 
 * Application changes often require **database migrations**.
 * Schema changes can cause cascading changes in code, making refactoring painful.
 
-### 3.2 Anemic Domain Model
+#### 3.2 Anemic Domain Model
 
 * Business logic ends up in service layers or stored procedures, not the model itself.
 * Leads to **procedural code** with poor encapsulation.
 
-### 3.3 Coupling to Persistence
+#### 3.3 Coupling to Persistence
 
 * Objects are tightly bound to table structures, making **testing and abstraction difficult**.
 * Violates the **Separation of Concerns** principle.
 
-### 3.4 Poor Fit for Complex Business Logic
+#### 3.4 Poor Fit for Complex Business Logic
 
 * Modeling aggregates, business rules, or workflows around tables leads to scattered logic.
 * Hard to implement concepts like **ubiquitous language** or **bounded contexts**.
@@ -63,22 +63,22 @@ In Database-Driven Design, the **relational database schema** becomes the source
 
 ## ⚙️ 4. Key Patterns in DBDD
 
-### 4.1 Table-Centric Modeling
+#### 4.1 Table-Centric Modeling
 
 * Tables map directly to classes or structs.
 * Foreign keys become object references.
 
-### 4.2 Stored Procedures for Logic
+#### 4.2 Stored Procedures for Logic
 
 * Business rules and workflows are encoded into SQL stored procedures.
 * Reduces duplication, but makes testing and version control harder.
 
-### 4.3 ORM-First Development
+#### 4.3 ORM-First Development
 
 * Tools like Hibernate, EF Core, or Sequelize are used to auto-generate models.
 * Migrations often driven by schema diffs.
 
-### 4.4 Repository as Table Wrapper
+#### 4.4 Repository as Table Wrapper
 
 * Repositories act more like **table access utilities**, with minimal domain understanding.
 * Methods like `findAll()`, `save()`, and `deleteById()` dominate.
@@ -125,24 +125,24 @@ Many teams start with DBDD and eventually hit its limits. Signs it's time to evo
 
 Yes — DBDD and DDD *can* coexist when each is used in its appropriate layer and role.
 
-### 8.1 Different Layers, Different Priorities
+#### 8.1 Different Layers, Different Priorities
 
 * Use **DDD** in the domain and application layers where business logic lives.
 * Use **DBDD** in the infrastructure and persistence layers to model storage and reporting.
 
 > Example: A rich `Order` aggregate can be stored using a normalized SQL schema, with translation layers in between.
 
-### 8.2 Gradual Adoption with Anti-Corruption Layers
+#### 8.2 Gradual Adoption with Anti-Corruption Layers
 
 * In legacy systems, wrap the database schema with an ACL so that domain logic evolves independently.
 * This allows a progressive transition from DBDD to DDD.
 
-### 8.3 Combine for Read/Write Optimization (CQRS)
+#### 8.3 Combine for Read/Write Optimization (CQRS)
 
 * Use **DDD** for commands and complex workflows.
 * Use **DBDD** for simple read models or reporting views.
 
-### 8.4 Apply DBDD to Generic Subdomains
+#### 8.4 Apply DBDD to Generic Subdomains
 
 * Use DBDD in parts of the system like authentication, logging, or permissions.
 * Focus DDD modeling efforts on the **Core Domain**.

--- a/docs/pages/articles/domain-driven-design.md
+++ b/docs/pages/articles/domain-driven-design.md
@@ -10,7 +10,7 @@ This guide covers the **core strategic and tactical patterns** you need to imple
 
 Strategic DDD focuses on **organizational and architectural structure** — how to align software boundaries with business reality.
 
-### 1.1 Bounded Contexts
+#### 1.1 Bounded Contexts
 
 A *bounded context* defines a **semantic boundary** within which a particular domain model applies. Different bounded contexts can use the same terms to mean different things.
 
@@ -24,7 +24,7 @@ A *bounded context* defines a **semantic boundary** within which a particular do
 
 ---
 
-### 1.2 Ubiquitous Language
+#### 1.2 Ubiquitous Language
 
 Inside each bounded context, developers and domain experts **use the same terminology** — in conversation, code, and documentation.
 
@@ -38,7 +38,7 @@ Inside each bounded context, developers and domain experts **use the same termin
 
 ---
 
-### 1.3 Subdomains
+#### 1.3 Subdomains
 
 Not all parts of the system are equally important.
 
@@ -53,7 +53,7 @@ Not all parts of the system are equally important.
 
 ---
 
-### 1.4 Context Mapping
+#### 1.4 Context Mapping
 
 Defines the **relationships** between different bounded contexts.
 
@@ -72,7 +72,7 @@ Defines the **relationships** between different bounded contexts.
 
 Once you've defined your bounded contexts, DDD provides **tactical tools** to model the internals.
 
-### 2.1 Entities
+#### 2.1 Entities
 
 Objects with:
 
@@ -83,7 +83,7 @@ Objects with:
 
 ---
 
-### 2.2 Value Objects
+#### 2.2 Value Objects
 
 * **Immutable**
 * No identity
@@ -94,7 +94,7 @@ Objects with:
 
 ---
 
-### 2.3 Aggregates and Aggregate Roots
+#### 2.3 Aggregates and Aggregate Roots
 
 Aggregates are **clusters of related entities and value objects** that are treated as a single unit of consistency.
 
@@ -105,7 +105,7 @@ Aggregates are **clusters of related entities and value objects** that are treat
 
 ---
 
-### 2.4 Domain Services
+#### 2.4 Domain Services
 
 Some domain logic doesn’t fit into a single entity or value object.
 
@@ -119,7 +119,7 @@ Domain services:
 
 ---
 
-### 2.5 Repositories
+#### 2.5 Repositories
 
 Repositories **abstract the persistence layer**, providing access to aggregates without leaking data storage concerns.
 
@@ -130,7 +130,7 @@ Repositories **abstract the persistence layer**, providing access to aggregates 
 
 ---
 
-### 2.6 Factories
+#### 2.6 Factories
 
 Factories handle **complex creation logic** when constructors are insufficient.
 
@@ -141,7 +141,7 @@ Factories handle **complex creation logic** when constructors are insufficient.
 
 ---
 
-### 2.7 Domain Events
+#### 2.7 Domain Events
 
 Domain events **capture significant business occurrences**.
 
@@ -155,7 +155,7 @@ Domain events **capture significant business occurrences**.
 
 ## 📼 3. Architectural Implications
 
-### 3.1 Layered Architecture
+#### 3.1 Layered Architecture
 
 Typical layering in DDD:
 
@@ -167,7 +167,7 @@ Typical layering in DDD:
 
 ---
 
-### 3.2 Anti-Corruption Layers (ACL)
+#### 3.2 Anti-Corruption Layers (ACL)
 
 ACLs sit at the **boundary between contexts** to **translate models** and protect your internal domain from leaking in external constraints or inconsistencies.
 
@@ -175,7 +175,7 @@ ACLs sit at the **boundary between contexts** to **translate models** and protec
 
 ---
 
-### 3.3 Integration and Messaging
+#### 3.3 Integration and Messaging
 
 In modern systems (microservices, event-driven), DDD aligns well with asynchronous messaging:
 

--- a/docs/pages/articles/program-to-an-interface.md
+++ b/docs/pages/articles/program-to-an-interface.md
@@ -1,7 +1,7 @@
 # 🌟 Program to an Interface
 
 
-### Overview
+#### Overview
 
 **"Program to an interface, not an implementation" isn’t just some dry software mantra — it’s a timeless design philosophy with real bite.** It helps your code stay nimble, modular, and ready for whatever weird feature request comes flying your way at 4 PM on a Friday.
 
@@ -9,9 +9,9 @@
 
 ---
 
-### 💡 Design Philosophy vs. Language Feature
+#### 💡 Design Philosophy vs. Language Feature
 
-#### ✅ **Design Philosophy**
+##### ✅ **Design Philosophy**
 
 This principle isn’t about syntax; it’s about **how you think**. Programming to an interface means writing code that depends on *what something does*, not *how it does it*. And that leads to:
 
@@ -22,7 +22,7 @@ This principle isn’t about syntax; it’s about **how you think**. Programming
 
 Any language that supports abstraction — interfaces, traits, duck typing, protocols, vibes — can ride this train.
 
-#### ⚙️ **Language Feature**
+##### ⚙️ **Language Feature**
 
 Languages help in different ways:
 
@@ -35,7 +35,7 @@ Languages help in different ways:
 
 ---
 
-### 📦 Real-World Example
+#### 📦 Real-World Example
 
 ```java
 interface PaymentProcessor {
@@ -53,7 +53,7 @@ Your app doesn’t care which one it’s using. It just calls `charge()` and get
 
 ---
 
-### 🔑 Takeaway
+#### 🔑 Takeaway
 
 Think of this principle as your software design compass:
 

--- a/docs/pages/articles/the-misconceptions-of-automated-testing.md
+++ b/docs/pages/articles/the-misconceptions-of-automated-testing.md
@@ -10,7 +10,7 @@ This article aims to clear up the confusion around automated testing: what it is
 
 Automated testing refers to the practice of writing code that verifies the correctness of other code. These tests are run automatically and repeatedly — during development, on every commit, and before deployments — to ensure that behavior remains correct over time.
 
-### Key Categories of Automated Tests:
+#### Key Categories of Automated Tests:
 
 * **Unit Tests** – test small, isolated units of logic (functions, methods)
 * **Integration Tests** – test the interaction between components or systems
@@ -34,7 +34,7 @@ TDD encourages thoughtful design, fast feedback, and a robust safety net for fut
 
 ## 🚫 What Automated Testing *Is Not*
 
-### Misconception: “If something broke in production, you didn’t test it.”
+#### Misconception: “If something broke in production, you didn’t test it.”
 
 A real example: A language model (LLM) mistakenly placed a link in the wrong menu. A manager noticed it and asked, “Didn’t you test?”
 
@@ -101,13 +101,13 @@ They should be fast, isolated, and deterministic. Good unit tests help prevent r
 
 Two popular mental models exist to guide test strategy:
 
-### The Testing Pyramid:
+#### The Testing Pyramid:
 
 * Base: **Unit tests** (fast, numerous)
 * Middle: **Integration tests** (fewer, broader scope)
 * Top: **E2E tests** (few, slowest)
 
-### The Testing Trophy:
+#### The Testing Trophy:
 
 * Emphasizes **more integration tests** than unit tests
 * Still includes E2E at the top, but acknowledges the growing ease and value of integration-level testing in modern apps
@@ -132,22 +132,22 @@ Focus your testing effort on **your business logic, data transformations, and ed
 
 ## 🧰 Writing Better Tests
 
-### 1. **Name tests clearly**
+#### 1. **Name tests clearly**
 
 * Good: `it('should update a user's email when confirmed')`
 * Bad: `it('does something')`
 
-### 2. **Avoid over-mocking**
+#### 2. **Avoid over-mocking**
 
 * Mocks are powerful but can lead to brittle, misleading tests
 * Prefer real collaborators where possible, especially in integration tests
 
-### 3. **Keep tests focused**
+#### 3. **Keep tests focused**
 
 * One behavior per test
 * Don’t assert on every UI element in one mega-test
 
-### 4. **Use test data factories**
+#### 4. **Use test data factories**
 
 * Avoid repetitive fixtures or hardcoded data
 
@@ -155,18 +155,18 @@ Focus your testing effort on **your business logic, data transformations, and ed
 
 ## 🔍 Types of Higher-Level Tests
 
-### End-to-End (E2E) Tests
+#### End-to-End (E2E) Tests
 
 * Simulate user flows (e.g., login, checkout)
 * Validate app behavior from front to back
 * Can be slow but invaluable for confidence
 
-### Acceptance Tests
+#### Acceptance Tests
 
 * Written to reflect business requirements
 * Answer the question: *Does this do what the business/user expects?*
 
-### Stress Tests
+#### Stress Tests
 
 * Push the app beyond its normal load
 * Uncover memory leaks, concurrency issues, or performance bottlenecks

--- a/docs/pages/articles/the_fragile_genius_of_llms.md
+++ b/docs/pages/articles/the_fragile_genius_of_llms.md
@@ -2,13 +2,13 @@
 
 ---
 
-### Introduction: The Paradox of LLMs
+#### Introduction: The Paradox of LLMs
 
 LLMs are among the most powerful tools in today’s digital toolkit. They translate languages, write essays, summarize books, brainstorm marketing ideas, generate code—and yes, analyze bank statements. But they come with a fundamental flaw that often goes under-discussed: **inconsistent accuracy**. When it comes to deterministic tasks, like computing total balances from years of financial data or categorizing expenses, LLMs can be surprisingly effective—**until they aren't.**
 
 ---
 
-### Use Case 1: Uploading Years of Bank Records
+#### Use Case 1: Uploading Years of Bank Records
 
 Let’s say you feed an LLM several years' worth of bank transactions in tabular format. You ask it: *“What’s my total net inflow or current balance?”*
 
@@ -24,7 +24,7 @@ Because LLMs are **stochastic by design**. Unlike spreadsheets or Python scripts
 
 ---
 
-### Use Case 2: Categorizing Expenses
+#### Use Case 2: Categorizing Expenses
 
 Expense categorization plays more to an LLM's strengths:
 - Understanding contextual nuances of vendors and descriptions.
@@ -40,7 +40,7 @@ In this domain, LLMs often outperform traditional rules-based systems.
 
 ---
 
-### The Achilles' Heel: Auditing and Verifiability
+#### The Achilles' Heel: Auditing and Verifiability
 
 If you ask: *“Why did you get this number?”* or *“Which rows did you include in this category?”*—you may get a nice-sounding answer, but not a verifiable trace.
 
@@ -55,7 +55,7 @@ You may need to re-run the task multiple times, check results manually, or add r
 
 ---
 
-### Stability vs. Stochasticity: The Human Need for Certainty
+#### Stability vs. Stochasticity: The Human Need for Certainty
 
 Humans don’t just prefer stability—we *depend* on it. Our decisions, our predictions, and our institutions are built on unshakable foundations:
 
@@ -77,7 +77,7 @@ When it comes to tax reports, compliance audits, investor statements, or fraud d
 
 ---
 
-### Where We Go From Here
+#### Where We Go From Here
 
 To responsibly deploy LLMs in data-sensitive contexts, we need:
 
@@ -88,7 +88,7 @@ To responsibly deploy LLMs in data-sensitive contexts, we need:
 
 ---
 
-### Conclusion: Amazing… with a Caveat
+#### Conclusion: Amazing… with a Caveat
 
 LLMs are miraculous, but not magical. Their strength lies in reasoning, language, and pattern recognition—not numerical accuracy or repeatability.
 

--- a/docs/pages/articles/top-10-website-features.md
+++ b/docs/pages/articles/top-10-website-features.md
@@ -4,7 +4,7 @@ Here are the **top 10 features every website should have**, regardless of indust
 
 * * *
 
-### 1. **Clear Navigation**
+#### 1. **Clear Navigation**
 
 A website’s navigation structure should be intuitive and consistent across pages. Key elements:
 
@@ -19,7 +19,7 @@ A website’s navigation structure should be intuitive and consistent across pag
 
 * * *
 
-### 2. **Responsive Design (Mobile-Friendly)**
+#### 2. **Responsive Design (Mobile-Friendly)**
 
 With mobile traffic surpassing desktop in many sectors, websites must:
 
@@ -32,7 +32,7 @@ With mobile traffic surpassing desktop in many sectors, websites must:
 
 * * *
 
-### 3. **Fast Load Times**
+#### 3. **Fast Load Times**
 
 Speed directly impacts user experience and SEO. Ensure:
 
@@ -45,7 +45,7 @@ Speed directly impacts user experience and SEO. Ensure:
 
 * * *
 
-### 4. **Strong Visual Hierarchy & Design**
+#### 4. **Strong Visual Hierarchy & Design**
 
 Good design guides users’ attention and supports your brand:
 
@@ -60,7 +60,7 @@ Good design guides users’ attention and supports your brand:
 
 * * *
 
-### 5. **Secure HTTPS Connection**
+#### 5. **Secure HTTPS Connection**
 
 Security is essential, especially for any site collecting user data:
 
@@ -73,7 +73,7 @@ Security is essential, especially for any site collecting user data:
 
 * * *
 
-### 6. **Accessible to All Users**
+#### 6. **Accessible to All Users**
 
 Your website should meet basic accessibility standards (WCAG 2.1):
 
@@ -88,7 +88,7 @@ Your website should meet basic accessibility standards (WCAG 2.1):
 
 * * *
 
-### 7. **Contact Information & Forms**
+#### 7. **Contact Information & Forms**
 
 Let users reach you easily:
 
@@ -105,7 +105,7 @@ Let users reach you easily:
 
 
 
-### 8. **Clear Value Proposition**
+#### 8. **Clear Value Proposition**
 
 Immediately communicate what your business does and why it matters:
 
@@ -118,7 +118,7 @@ Immediately communicate what your business does and why it matters:
 
 * * *
 
-### 9. **Content That Educates or Converts**
+#### 9. **Content That Educates or Converts**
 
 Content should be structured, SEO-friendly, and purposeful:
 
@@ -131,7 +131,7 @@ Content should be structured, SEO-friendly, and purposeful:
 
 * * *
 
-### 10. **Analytics and SEO Foundations**
+#### 10. **Analytics and SEO Foundations**
 
 To track and improve performance:
 


### PR DESCRIPTION
## Summary
- forbid `<h3>` in Articles agent rules
- replace all level-3 markdown headings with level-4 in articles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687557b53b0c832d828b3107e9c3b81b