### PR TITLE
Fix article heading levels

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -40,15 +40,15 @@ nav:                             # make your own nav order
       - DIRECTIVE.md: templates1/DIRECTIVE.md
   - Articles:
       - Clean Architecture: articles/clean-architecture.md
-      - A Database-Driven Design: articles/database-driven-design.md
+      - RUBE Four-Point Design: articles/rube.md
       - The Fragile Genius of LLMs: articles/the_fragile_genius_of_llms.md
+      - A Database-Driven Design: articles/database-driven-design.md
       - The Misconceptions of Automated Testing: articles/the-misconceptions-of-automated-testing.md
       - Domain-Driven Design: articles/domain-driven-design.md
       - Program to an Interface: articles/program-to-an-interface.md
       - Code Review Best Practices: articles/code-review-best-practices.md
       - Top 10 Website Features: articles/top-10-website-features.md
       - Using Puppeteer to Simulate User Interaction: articles/using-puppeteer-to-simulate-user-interaction.md
-      - RUBE Four-Point Design: articles/rube.md
       - Continuous Integration: articles/continuous-integration.md
       - AI-Generated Content and Attribution: articles/ai-generated-content-and-attribution.md
       - Best Practices for Closing Pull Requests: articles/closing-pull-requests.md

--- a/docs/pages/articles/clean-architecture.md
+++ b/docs/pages/articles/clean-architecture.md
@@ -38,7 +38,7 @@ flowchart TD
 </pre>
 </div>
 
-### Key Rule:
+#### Key Rule:
 
 > **Dependencies must point inward** — outer layers can depend on inner layers, but never the reverse.
 
@@ -46,7 +46,7 @@ flowchart TD
 
 ## 🏛️ 2. Core Layers Explained
 
-### 2.1 Domain Layer (Entities)
+#### 2.1 Domain Layer (Entities)
 
 * Contains **business objects and rules**
 * Should have **no dependencies** on other layers
@@ -56,7 +56,7 @@ flowchart TD
 
 ---
 
-### 2.2 Application Layer (Use Cases)
+#### 2.2 Application Layer (Use Cases)
 
 * Contains **application-specific business rules**
 * Coordinates the flow of data to/from entities and external services
@@ -66,7 +66,7 @@ flowchart TD
 
 ---
 
-### 2.3 Interface Adapters (Controllers, Presenters, Gateways)
+#### 2.3 Interface Adapters (Controllers, Presenters, Gateways)
 
 * Converts data between formats: from UI/database into something the application layer understands
 * Implements interfaces defined in the inner layers
@@ -75,7 +75,7 @@ flowchart TD
 
 ---
 
-### 2.4 Frameworks & Drivers (Infrastructure)
+#### 2.4 Frameworks & Drivers (Infrastructure)
 
 * External tools and services: UI frameworks, ORMs, databases, messaging systems
 * Can be swapped out without affecting core logic

--- a/docs/pages/articles/the_fragile_genius_of_llms.md
+++ b/docs/pages/articles/the_fragile_genius_of_llms.md
@@ -2,13 +2,13 @@
 
 ---
 
-#### Introduction: The Paradox of LLMs
+## Introduction: The Paradox of LLMs
 
 LLMs are among the most powerful tools in today’s digital toolkit. They translate languages, write essays, summarize books, brainstorm marketing ideas, generate code—and yes, analyze bank statements. But they come with a fundamental flaw that often goes under-discussed: **inconsistent accuracy**. When it comes to deterministic tasks, like computing total balances from years of financial data or categorizing expenses, LLMs can be surprisingly effective—**until they aren't.**
 
 ---
 
-#### Use Case 1: Uploading Years of Bank Records
+## Use Case 1: Uploading Years of Bank Records
 
 Let’s say you feed an LLM several years' worth of bank transactions in tabular format. You ask it: *“What’s my total net inflow or current balance?”*
 
@@ -24,7 +24,7 @@ Because LLMs are **stochastic by design**. Unlike spreadsheets or Python scripts
 
 ---
 
-#### Use Case 2: Categorizing Expenses
+## Use Case 2: Categorizing Expenses
 
 Expense categorization plays more to an LLM's strengths:
 - Understanding contextual nuances of vendors and descriptions.
@@ -40,7 +40,7 @@ In this domain, LLMs often outperform traditional rules-based systems.
 
 ---
 
-#### The Achilles' Heel: Auditing and Verifiability
+## The Achilles' Heel: Auditing and Verifiability
 
 If you ask: *“Why did you get this number?”* or *“Which rows did you include in this category?”*—you may get a nice-sounding answer, but not a verifiable trace.
 
@@ -55,7 +55,7 @@ You may need to re-run the task multiple times, check results manually, or add r
 
 ---
 
-#### Stability vs. Stochasticity: The Human Need for Certainty
+## Stability vs. Stochasticity: The Human Need for Certainty
 
 Humans don’t just prefer stability—we *depend* on it. Our decisions, our predictions, and our institutions are built on unshakable foundations:
 
@@ -77,7 +77,7 @@ When it comes to tax reports, compliance audits, investor statements, or fraud d
 
 ---
 
-#### Where We Go From Here
+## Where We Go From Here
 
 To responsibly deploy LLMs in data-sensitive contexts, we need:
 
@@ -88,7 +88,7 @@ To responsibly deploy LLMs in data-sensitive contexts, we need:
 
 ---
 
-#### Conclusion: Amazing… with a Caveat
+## Conclusion: Amazing… with a Caveat
 
 LLMs are miraculous, but not magical. Their strength lies in reasoning, language, and pattern recognition—not numerical accuracy or repeatability.
 


### PR DESCRIPTION
## Summary
- demote h3s to h4s in Clean Architecture article
- upgrade h4s to h2s in The Fragile Genius of LLMs article
- update Articles navigation order

## Testing
- `pip install -r requirements.txt`
- `mkdocs build -f docs/mkdocs.yml -s`

------
https://chatgpt.com/codex/tasks/task_b_68759d795588832da39a2ab3432eb48a