### PR TITLE
Enable Material dark mode toggle

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,10 +11,15 @@ theme:
     - scheme: default            # ── light mode ──
       primary: indigo
       accent: indigo
-    - scheme: slate              # ── dark mode ──
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
+    - scheme: slate              # ── dark mode ──
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   features:
     - navigation.tabs
     - navigation.sections


### PR DESCRIPTION
## Summary
- configure palette settings in `mkdocs.yml` to support manual dark mode toggle

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6875f2fb56f4832d9a13441b984bf188